### PR TITLE
DEVOPS-473: Add moved-to-monorepo notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> ⚠️ **Moved to the monorepo.**
+> This module now lives in [`opstimus/terraform-modules`](https://github.com/opstimus/terraform-modules) at `modules/aws-rds`.
+>
+> ```hcl
+> source = "git::https://github.com/opstimus/terraform-modules.git//modules/aws-rds?ref=aws-rds/v2.0.1"
+> ```
+>
+> This repository remains for existing consumers; new development happens in the monorepo.
 # AWS RDS Module
 
 ## Description


### PR DESCRIPTION
Adds a notice to README.md pointing consumers to the `aws-rds` module now living in opstimus/terraform-modules (ref `aws-rds/v2.0.1`).